### PR TITLE
Update application dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,14 +7,14 @@ repositories {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:22.1.1'
+    compile 'com.android.support:support-v4:23.1.0'
     compile 'com.androidplot:androidplot-core:0.6.2-SNAPSHOT@aar'
     compile 'com.sensirion:libble:1.0.0'
 }
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion '22.0.1'
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.2'
+        classpath 'com.android.tools.build:gradle:1.3.1'
     }
 }
 


### PR DESCRIPTION
- Compile against the Android API 23
- Update grade tools to the version ‘1.3.1’
- Update Android build tools to the version ’23.0.1’
- Update Android support repository to the version ’23.1.0’
