### PR TITLE
Close 'Connection in Progress' dialog on device disconnection

### DIFF
--- a/app/src/main/java/com/sensirion/smartgadget/view/device_management/ScanDeviceFragment.java
+++ b/app/src/main/java/com/sensirion/smartgadget/view/device_management/ScanDeviceFragment.java
@@ -447,8 +447,12 @@ public class ScanDeviceFragment extends ParentListFragment implements ScanListen
      */
     @Override
     public void onDeviceDisconnected(@NonNull final BleDevice device) {
-        Log.i(TAG, String.format("onDeviceConnected -> %s has lost the connected with the device: %s ", TAG, device.getAddress()));
-        onDeviceConnectionStateChange(device.getAddress());
+        final String deviceAddress = device.getAddress();
+        Log.i(TAG, String.format("onDeviceConnected -> %s has lost the connected with the device: %s ", TAG, deviceAddress));
+        onDeviceConnectionStateChange(deviceAddress);
+        if (mConnectionDialogDeviceAddress != null && mConnectionDialogDeviceAddress.equals(deviceAddress)) {
+            dismissConnectingProgressDialog(deviceAddress);
+        }
     }
 
     private void onDeviceConnectionStateChange(@NonNull final String deviceAddress) {


### PR DESCRIPTION
- Fixes a bug where, in case a device becomes disconnected while there
  is a connection dialog waiting for that particular device synchronization,
  that connection dialog stayed open for a few more seconds.
