### PR TITLE
SGA-60: Refactor 'SmartgadgetPreferenceFragment'

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,17 +1,6 @@
 apply plugin: 'com.android.application'
 apply from: '../gradle-helpers.gradle'
 
-// additional repository for androidplot
-repositories {
-    maven { url 'https://oss.sonatype.org/content/groups/public' }
-}
-
-dependencies {
-    compile 'com.android.support:support-v4:23.1.0'
-    compile 'com.androidplot:androidplot-core:0.6.2-SNAPSHOT@aar'
-    compile 'com.sensirion:libble:1.0.0'
-}
-
 android {
     compileSdkVersion 23
     buildToolsVersion '23.0.2'
@@ -19,4 +8,22 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    repositories {
+        // additional repository for androidplot
+        maven { url 'https://oss.sonatype.org/content/groups/public' }
+    }
+    dependencies {
+        compile 'com.android.support:support-v4:23.1.0'
+        compile 'com.androidplot:androidplot-core:0.6.2-SNAPSHOT@aar'
+        compile 'com.sensirion:libble:1.0.0'
+        compile 'com.jakewharton:butterknife:7.0.1'
+    }
+    // Custom options for the Butterknife library
+    lintOptions {
+        disable 'InvalidPackage'
+    }
+    packagingOptions {
+        exclude 'META-INF/services/javax.annotation.processing.Processor'
+    }
+    // End of the custom options for the Butterknife library
 }

--- a/app/src/main/java/com/sensirion/smartgadget/view/preference/adapter/PreferenceAdapter.java
+++ b/app/src/main/java/com/sensirion/smartgadget/view/preference/adapter/PreferenceAdapter.java
@@ -1,6 +1,5 @@
 package com.sensirion.smartgadget.view.preference.adapter;
 
-import android.content.Context;
 import android.graphics.Typeface;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -12,6 +11,11 @@ import android.widget.TextView;
 import com.sensirion.smartgadget.R;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
 
 public class PreferenceAdapter extends BaseAdapter {
 
@@ -19,11 +23,12 @@ public class PreferenceAdapter extends BaseAdapter {
     private final Typeface mTypeface;
 
     @NonNull
-    private final ArrayList<PreferenceObject> mPreferenceList = new ArrayList<>();
+    private final List<PreferenceObject> mPreferenceList =
+            Collections.synchronizedList(new ArrayList<PreferenceObject>());
 
-    public PreferenceAdapter(@NonNull final Context context) {
+    public PreferenceAdapter(@NonNull final Typeface typeface) {
         super();
-        mTypeface = Typeface.createFromAsset(context.getAssets(), "HelveticaNeueLTStd-Cn.otf");
+        mTypeface = typeface;
     }
 
     /**
@@ -56,25 +61,32 @@ public class PreferenceAdapter extends BaseAdapter {
     @Nullable
     @Override
     public View getView(final int position,
-                        @Nullable final View convertView,
+                        @Nullable View view,
                         @NonNull final ViewGroup parent) {
-        final View view;
-        if (convertView == null) {
+
+        final PreferenceViewHolder holder;
+        if (view != null) {
+            holder = (PreferenceViewHolder) view.getTag();
+        } else {
             view = View.inflate(parent.getContext(), R.layout.listitem_preference, null);
-        } else {
-            view = convertView;
+            holder = new PreferenceViewHolder(view);
+            view.setTag(holder);
         }
+
         final PreferenceObject preference = mPreferenceList.get(position);
-        final TextView titleTextView = (TextView) view.findViewById(R.id.preference_title);
-        titleTextView.setTypeface(mTypeface);
-        titleTextView.setText(preference.title.trim());
-        final TextView summaryTextView = (TextView) view.findViewById(R.id.preference_summary);
-        summaryTextView.setTypeface(mTypeface);
+
+        holder.summaryTextView.setText(preference.summary);
+
+        holder.titleTextView.setTypeface(mTypeface);
+        holder.titleTextView.setText(preference.title.trim());
+
+        holder.summaryTextView.setTypeface(mTypeface);
         if (preference.summary == null) {
-            summaryTextView.setText("");
+            holder.summaryTextView.setText("");
         } else {
-            summaryTextView.setText(preference.summary.trim());
+            holder.summaryTextView.setText(preference.summary.trim());
         }
+
         view.setOnClickListener(preference.clickListener);
         return view;
     }
@@ -88,14 +100,26 @@ public class PreferenceAdapter extends BaseAdapter {
 
     /**
      * Adds a preference to the preference list.
-     * @param title of the preference.
-     * @param summary of the preference.
+     *
+     * @param title         of the preference.
+     * @param summary       of the preference.
      * @param clickListener that will be executed when the preference item is clicked.
      */
     public void addPreference(@NonNull final String title,
                               @Nullable final String summary,
                               @NonNull final View.OnClickListener clickListener) {
         mPreferenceList.add(new PreferenceObject(title, summary, clickListener));
+    }
+
+    static class PreferenceViewHolder {
+        @Bind(R.id.preference_summary)
+        TextView summaryTextView;
+        @Bind(R.id.preference_title)
+        TextView titleTextView;
+
+        PreferenceViewHolder(@NonNull final View view) {
+            ButterKnife.bind(this, view);
+        }
     }
 
     private static class PreferenceObject {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,7 +48,7 @@
     <!-- http://smart.sensirion.com/ -->
     <string name="txt_about_char_copyright">\u00A9</string>
     <!-- © -->
-    <string name="txt_about_sensirionag">Copyright Sensirion AG, Switzerland</string>
+    <string name="about_sensirion_ag">Copyright Sensirion AG, Switzerland</string>
     <!-- ScanDeviceFragment -->
     <string name="label_devicescan">SmartGadget Scan</string>
     <string name="action_refresh">Refresh</string>

--- a/app/src/main/res/values/typeface_locations.xml
+++ b/app/src/main/res/values/typeface_locations.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="typeface_condensed">HelveticaNeueLTStd-Cn.otf</string>
+    <string name="typeface_bold">HelveticaNeueLTStd-Bd.otf</string>
+</resources>

--- a/proguard.cfg
+++ b/proguard.cfg
@@ -60,7 +60,7 @@
 -dontwarn **CompatHoneycomb
 -dontwarn org.htmlcleaner.*
 
-  #Deletes the logs from the published code.
+#Deletes the logs from the published code.
 -assumenosideeffects class android.util.Log {
     public static boolean isLoggable(java.lang.String, int);
     public static int v(...);
@@ -72,3 +72,17 @@
 -keepclassmembers class fqcn.of.javascript.interface.for.webview {
     public *;
 }
+
+###### Start of Butterknife exceptions ##########
+-keep class butterknife.** { *; }
+-dontwarn butterknife.internal.**
+-keep class **$$ViewBinder { *; }
+
+-keepclasseswithmembernames class * {
+    @butterknife.* <fields>;
+}
+
+-keepclasseswithmembernames class * {
+    @butterknife.* <methods>;
+}
+######## End of Butterknife exceptions ##########


### PR DESCRIPTION
- Bind XML strings using the BUTTERKNIFE library
- Refactor de preference adapter to use the ViewHolder pattern
- Prefer ‘getContext()’ rather than ‘getParent()’  whether possible
- Rename all prefix named ‘obtain’ to ‘get’ in order to follow project
  conventions
- Refactor code for avoiding lines with a length greater than 120
  characters
- Avoid some possible NullPointerExceptions if the parent activity is
  not a ‘MainActivity’. (Logs an error instead)
