### PR TITLE
Refactor XmlFloatExtractor.java

### DIFF
--- a/app/src/main/java/com/sensirion/smartgadget/utils/XmlFloatExtractor.java
+++ b/app/src/main/java/com/sensirion/smartgadget/utils/XmlFloatExtractor.java
@@ -1,15 +1,24 @@
 package com.sensirion.smartgadget.utils;
 
 import android.content.Context;
+import android.support.annotation.DimenRes;
 import android.support.annotation.NonNull;
 import android.util.TypedValue;
 
+public final class XmlFloatExtractor {
 
-public abstract class XmlFloatExtractor {
+    private XmlFloatExtractor(){}
 
-    public static float getFloatValueFromId(@NonNull final Context context, final int resourceId) {
-        final TypedValue outValue = new TypedValue();
-        context.getResources().getValue(resourceId, outValue, true);
-        return outValue.getFloat();
+    /**
+     * Extracts a dimension value from the XML resources into a float.
+     * @param context needed to access the XML resources.
+     * @param resourceId that will be extracted into a float.
+     * @return {@link float} with the extracted float value.
+     */
+    public static float getFloatValueFromId(@NonNull final Context context,
+                                            @DimenRes final int resourceId) {
+        final TypedValue value = new TypedValue();
+        context.getResources().getValue(resourceId, value, true);
+        return value.getFloat();
     }
 }


### PR DESCRIPTION
- The class is a final class, not an abstract class, and has a private
  constructor for avoiding that an user instances it.
- Refactor ‘getFloatValueFromId’ method
  - Add ‘@DimenRes’ annotation
  - Add javadoc
