### PR TITLE
Line lenght small refactor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,17 +1,6 @@
 apply plugin: 'com.android.application'
 apply from: '../gradle-helpers.gradle'
 
-// additional repository for androidplot
-repositories {
-    maven { url 'https://oss.sonatype.org/content/groups/public' }
-}
-
-dependencies {
-    compile 'com.android.support:support-v4:23.1.0'
-    compile 'com.androidplot:androidplot-core:0.6.2-SNAPSHOT@aar'
-    compile 'com.sensirion:libble:1.0.0'
-}
-
 android {
     compileSdkVersion 23
     buildToolsVersion '23.0.2'
@@ -19,4 +8,22 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    repositories {
+        // additional repository for androidplot
+        maven { url 'https://oss.sonatype.org/content/groups/public' }
+    }
+    dependencies {
+        compile 'com.android.support:support-v4:23.1.0'
+        compile 'com.androidplot:androidplot-core:0.6.2-SNAPSHOT@aar'
+        compile 'com.sensirion:libble:1.0.0'
+        compile 'com.jakewharton:butterknife:7.0.1'
+    }
+    // Custom options for the Butterknife library
+    lintOptions {
+        disable 'InvalidPackage'
+    }
+    packagingOptions {
+        exclude 'META-INF/services/javax.annotation.processing.Processor'
+    }
+    // End of the custom options for the Butterknife library
 }

--- a/app/src/main/java/com/sensirion/smartgadget/view/history/HistoryResult.java
+++ b/app/src/main/java/com/sensirion/smartgadget/view/history/HistoryResult.java
@@ -13,7 +13,10 @@ import java.util.Map;
 public class HistoryResult {
 
     @NonNull
-    private final Map<String, List<RHTDataPoint>> mResultValues = Collections.synchronizedMap(new HashMap<String, List<RHTDataPoint>>());
+    private final Map<String, List<RHTDataPoint>> mResultValues =
+            Collections.synchronizedMap(
+                    new HashMap<String, List<RHTDataPoint>>()
+            );
 
     public HistoryResult(@NonNull final List<String> devices) {
         for (final String device : devices) {
@@ -36,7 +39,8 @@ public class HistoryResult {
      *
      * @param dataPoint that is going to be added.
      */
-    public void addResult(@NonNull final String deviceAddress, @NonNull final RHTDataPoint dataPoint) {
+    public void addResult(@NonNull final String deviceAddress,
+                          @NonNull final RHTDataPoint dataPoint) {
         mResultValues.get(deviceAddress).add(dataPoint);
     }
 
@@ -59,8 +63,12 @@ public class HistoryResult {
         final StringBuilder sb = new StringBuilder();
         for (final String deviceAddress : mResultValues.keySet()) {
             for (final RHTDataPoint datapoint : mResultValues.get(deviceAddress)) {
-                sb.append(String.format("\nDevice with address: %s - Temperature: %f - Humidity: %f, Seconds ago: %d",
-                        deviceAddress, datapoint.getTemperatureCelsius(), datapoint.getRelativeHumidity(), (System.currentTimeMillis() - datapoint.getTimestamp() / 1000)));
+                sb.append(
+                        String.format(
+                                "\nDevice with address: %s - %s",
+                                deviceAddress,
+                                datapoint.toString())
+                );
             }
         }
         return sb.toString();

--- a/proguard.cfg
+++ b/proguard.cfg
@@ -60,7 +60,7 @@
 -dontwarn **CompatHoneycomb
 -dontwarn org.htmlcleaner.*
 
-  #Deletes the logs from the published code.
+#Deletes the logs from the published code.
 -assumenosideeffects class android.util.Log {
     public static boolean isLoggable(java.lang.String, int);
     public static int v(...);
@@ -72,3 +72,17 @@
 -keepclassmembers class fqcn.of.javascript.interface.for.webview {
     public *;
 }
+
+###### Start of Butterknife exceptions ##########
+-keep class butterknife.** { *; }
+-dontwarn butterknife.internal.**
+-keep class **$$ViewBinder { *; }
+
+-keepclasseswithmembernames class * {
+    @butterknife.* <fields>;
+}
+
+-keepclasseswithmembernames class * {
+    @butterknife.* <methods>;
+}
+######## End of Butterknife exceptions ##########


### PR DESCRIPTION
- Refactor code for avoiding lines with a length greater than 120
  characters
- Use the RhtDatapoint ‘toString()’ overload when logging the received
  datapoint
