### PR TITLE
Fix aggregation of RH and T values for download

### DIFF
--- a/app/src/androidTest/java/com/sensirion/smartgadget/peripheral/rht_sensor/external/GadgetTestValue.java
+++ b/app/src/androidTest/java/com/sensirion/smartgadget/peripheral/rht_sensor/external/GadgetTestValue.java
@@ -1,0 +1,36 @@
+package com.sensirion.smartgadget.peripheral.rht_sensor.external;
+
+import android.support.annotation.NonNull;
+
+import com.sensirion.libsmartgadget.GadgetValue;
+
+import java.util.Date;
+
+class GadgetTestValue implements GadgetValue {
+
+    private Number mValue;
+    private Date mTimestamp;
+
+    GadgetTestValue(Number value, long timestamp) {
+        this.mValue = value;
+        this.mTimestamp = new Date(timestamp);
+    }
+
+    @NonNull
+    @Override
+    public Number getValue() {
+        return mValue;
+    }
+
+    @NonNull
+    @Override
+    public Date getTimestamp() {
+        return mTimestamp;
+    }
+
+    @NonNull
+    @Override
+    public String getUnit() {
+        return "";
+    }
+}

--- a/app/src/androidTest/java/com/sensirion/smartgadget/peripheral/rht_sensor/external/HistoryValueAggregatorTest.java
+++ b/app/src/androidTest/java/com/sensirion/smartgadget/peripheral/rht_sensor/external/HistoryValueAggregatorTest.java
@@ -1,0 +1,82 @@
+package com.sensirion.smartgadget.peripheral.rht_sensor.external;
+
+import android.support.annotation.NonNull;
+
+import com.sensirion.libsmartgadget.GadgetValue;
+import com.sensirion.smartgadget.peripheral.rht_utils.RHTDataPoint;
+
+import junit.framework.TestCase;
+
+public class HistoryValueAggregatorTest extends TestCase {
+
+    private RHTValueAggregator mAggregator;
+
+    public void setUp() throws Exception {
+        mAggregator = new HistoryValueAggregator();
+    }
+
+    public void testAggregateHumidityOnce() throws Exception {
+        assertNull(mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(23.5, 1)));
+    }
+
+    public void testAggregateTemperatureOnce() throws Exception {
+        assertNull(mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(23.5, 1)));
+    }
+
+    public void testAggregateNull() throws Exception {
+        try {
+            mAggregator.aggregateHumidityValue("abc", null);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertNotNull(ex);
+        }
+    }
+
+    public void testAggregateOnlyHumidity() throws Exception {
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(23.5, 1));
+        assertNull(mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(25, 1)));
+        assertNull(mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(25, 2)));
+        assertNull(mAggregator.aggregateHumidityValue("abd", new GadgetTestValue(23.5, 1)));
+    }
+
+    public void testAggregateOnlyTemperature() throws Exception {
+        mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(23.5, 1));
+        assertNull(mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(25, 1)));
+        assertNull(mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(25, 2)));
+        assertNull(mAggregator.aggregateTemperatureValue("abd", new GadgetTestValue(23.5, 1)));
+    }
+
+    public void testAggregateDifferentTimestamps() throws Exception {
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(23.5, 1));
+        assertNull(mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(25, 2)));
+    }
+
+    public void testAggregateDifferentAddress() throws Exception {
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(23.5, 1));
+        assertNull(mAggregator.aggregateTemperatureValue("abe", new GadgetTestValue(25, 1)));
+    }
+
+    public void testAggregateOne() throws Exception {
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(23.5, 1));
+        RHTDataPoint data = mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(25, 1));
+        assertNotNull(data);
+        assertEquals(23.5f, data.getRelativeHumidity());
+        assertEquals(25f, data.getTemperatureCelsius());
+        assertEquals(1L, data.getTimestamp());
+    }
+
+    public void testAggregateOutOfOrder() throws Exception {
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(23.5, 4));
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(24.5, 3));
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(25.5, 2));
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(26.5, 1));
+        assertNotNull(mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(25, 4)));
+        assertNotNull(mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(26, 3)));
+        assertNotNull(mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(27, 2)));
+        RHTDataPoint data = mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(28, 1));
+        assertNotNull(data);
+        assertEquals(26.5f, data.getRelativeHumidity());
+        assertEquals(28f, data.getTemperatureCelsius());
+        assertEquals(1L, data.getTimestamp());
+    }
+}

--- a/app/src/androidTest/java/com/sensirion/smartgadget/peripheral/rht_sensor/external/LiveValueAggregatorTest.java
+++ b/app/src/androidTest/java/com/sensirion/smartgadget/peripheral/rht_sensor/external/LiveValueAggregatorTest.java
@@ -1,0 +1,79 @@
+package com.sensirion.smartgadget.peripheral.rht_sensor.external;
+
+import com.sensirion.smartgadget.peripheral.rht_utils.RHTDataPoint;
+
+import junit.framework.TestCase;
+
+public class LiveValueAggregatorTest extends TestCase {
+
+    private RHTValueAggregator mAggregator;
+
+    public void setUp() throws Exception {
+        mAggregator = new LiveValueAggregator();
+    }
+
+    public void testAggregateHumidityOnce() throws Exception {
+        assertNull(mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(23.5, 1)));
+    }
+
+    public void testAggregateTemperatureOnce() throws Exception {
+        assertNull(mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(23.5, 1)));
+    }
+
+    public void testAggregateNull() throws Exception {
+        try {
+            mAggregator.aggregateHumidityValue("abc", null);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertNotNull(ex);
+        }
+    }
+
+    public void testAggregateOnlyHumidity() throws Exception {
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(23.5, 1));
+        assertNull(mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(25, 1)));
+        assertNull(mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(25, 2)));
+        assertNull(mAggregator.aggregateHumidityValue("abd", new GadgetTestValue(23.5, 1)));
+    }
+
+    public void testAggregateOnlyTemperature() throws Exception {
+        mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(23.5, 1));
+        assertNull(mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(25, 1)));
+        assertNull(mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(25, 2)));
+        assertNull(mAggregator.aggregateTemperatureValue("abd", new GadgetTestValue(23.5, 1)));
+    }
+
+    public void testAggregateDifferentTimestamps() throws Exception {
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(23.5, 1));
+        RHTDataPoint data = mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(25, 2));
+        assertNotNull(data);
+        assertEquals(23.5f, data.getRelativeHumidity());
+        assertEquals(25f, data.getTemperatureCelsius());
+        assertEquals(2L, data.getTimestamp());
+    }
+
+    public void testAggregateDifferentAddress() throws Exception {
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(23.5, 1));
+        assertNull(mAggregator.aggregateTemperatureValue("abe", new GadgetTestValue(25, 1)));
+    }
+
+    public void testAggregateOne() throws Exception {
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(23.5, 1));
+        RHTDataPoint data = mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(25, 1));
+        assertNotNull(data);
+        assertEquals(23.5f, data.getRelativeHumidity());
+        assertEquals(25f, data.getTemperatureCelsius());
+        assertEquals(1L, data.getTimestamp());
+    }
+
+    public void testAggregateOutOfOrder() throws Exception {
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(23.5, 4));
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(24.5, 3));
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(25.5, 2));
+        mAggregator.aggregateHumidityValue("abc", new GadgetTestValue(26.5, 1));
+        assertNotNull(mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(25, 4)));
+        assertNull(mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(26, 3)));
+        assertNull(mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(27, 2)));
+        assertNull(mAggregator.aggregateTemperatureValue("abc", new GadgetTestValue(28, 1)));
+    }
+}

--- a/app/src/main/java/com/sensirion/smartgadget/peripheral/rht_sensor/external/HistoryValueAggregator.java
+++ b/app/src/main/java/com/sensirion/smartgadget/peripheral/rht_sensor/external/HistoryValueAggregator.java
@@ -1,0 +1,21 @@
+package com.sensirion.smartgadget.peripheral.rht_sensor.external;
+
+import android.support.annotation.NonNull;
+
+import java.util.AbstractMap;
+
+/**
+ * Aggregates Logged values according to their time stamps.
+ */
+public class HistoryValueAggregator extends RHTValueAggregator<HistoryValueAggregator.HistoryAggregationKey> {
+
+    protected HistoryAggregationKey getAggregationKey(@NonNull String deviceAddress, long timestamp) {
+        return new HistoryAggregationKey(deviceAddress, timestamp);
+    }
+
+    protected static class HistoryAggregationKey extends AbstractMap.SimpleImmutableEntry<String, Long> {
+        public HistoryAggregationKey(String deviceAddress, long timestamp) {
+            super(deviceAddress, timestamp);
+        }
+    }
+}

--- a/app/src/main/java/com/sensirion/smartgadget/peripheral/rht_sensor/external/LiveValueAggregator.java
+++ b/app/src/main/java/com/sensirion/smartgadget/peripheral/rht_sensor/external/LiveValueAggregator.java
@@ -1,0 +1,17 @@
+package com.sensirion.smartgadget.peripheral.rht_sensor.external;
+
+import android.support.annotation.NonNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Aggregates live values, i.e. ignores time stamps for aggregation.
+ */
+public class LiveValueAggregator extends RHTValueAggregator<String> {
+
+    protected String getAggregationKey(@NonNull String deviceAddress, long timestamp) {
+        return deviceAddress;
+    }
+}


### PR DESCRIPTION
This fixes a serious bug in the download feature that would lose three out of four data points, see the commit message below.

Even after fixing this bug, there are still more strange issues, I documented them here: #31.

When downloading logged RH/T values, these do not arrive in pairs,
but independently. Also, they arrive in packets, so several RH values
might arrive before the corresponding T value does. The code to
aggregate these values in pairs did not account for this, losing
three out of four values by overwriting them in the aggregator.

There are now two different aggregation strategies for live and
logged data: for live values, the timestamp is ignored, for historic
values it is not.
