### PR TITLE
Android automatic refactor - ObsoleteLayoutParam

### DIFF
--- a/app/src/main/res/layout/fragment_manage_device.xml
+++ b/app/src/main/res/layout/fragment_manage_device.xml
@@ -152,7 +152,6 @@
                 android:layout_gravity="end"
                 android:layout_marginEnd="10dp"
                 android:layout_marginStart="8dp"
-                android:layout_weight="1"
                 android:background="@color/sensirion_grey_light"
                 android:text="@string/label_interval_second_singular"
                 android:textColor="@color/light_gray"


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ObsoleteLayoutParam".

While developing your application's views you might be specifying attributes in a view's artefact that are not necessary due to the nature of its parent. In this PR, those attributes were replaced by a comment.

I have made a previous validation of the changes and they seem correct.
Unfortunately, this tool is not able keep the original whitespace of the files, so comparison without ignoring whitespace might be confusing.
Please consider the changes and let me know if you agree with them.

Best,
Luis